### PR TITLE
feat: プロジェクト全体で使用するマクロ定義を追加

### DIFF
--- a/docs/development_log.md
+++ b/docs/development_log.md
@@ -23,3 +23,10 @@
 - 実装内容: Move 'core/message' -> 'base/message'
   - 追加予定のcore/memoryがmessageへ依存するため、一方向依存を守る
   - engine/base/message.hへ変更
+
+## Add base/macors
+
+- 実装内容: メモリアロケータ実装の準備として、KIB, MIB, GIB等の共通マクロを用意する
+  - KIB, MIB, GIB
+  - 今後のテスト関数の用意のため、NO_COVERAGEを追加
+- ブランチ名称: feat/base-macros

--- a/include/engine/base/choro_macros.h
+++ b/include/engine/base/choro_macros.h
@@ -1,0 +1,23 @@
+#ifndef CHOCO_MACROS_H
+#define CHOCO_MACROS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+#ifdef __clang__
+  #define NO_COVERAGE __attribute__((no_profile_instrument_function))
+#else
+  #define NO_COVERAGE
+#endif
+
+#define KIB ((size_t)(1ULL << 10))
+#define MIB ((size_t)(1ULL << 20))
+#define GIB ((size_t)(1ULL << 30))
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
- base/choco_macros
- 名前衝突防止のためmacros -> choco_macrosを使用
- メモリアロケータ実装の準備のため、KIB、MIB、GIBを用意
- 将来のテスト関数の追加のためにNO_COVERAGE追加