### PR TITLE
fix: memory_systemの内部状態をapplicationではなくmemory_systemで保有するよう変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "assert.h": "c",
-        "oc_hist.h": "c"
+        "oc_hist.h": "c",
+        "choco_macros.h": "c"
     }
 }

--- a/docs/development_log.md
+++ b/docs/development_log.md
@@ -90,13 +90,17 @@ step2 TODO:
    - [x] 初期化コード / ウィンドウ生成コード作成
    - [x] makefile修正
    - [x] 実行確認
- - [] platform層をstrategy化
+ - [x] platform層をstrategy化
    - [x] strategy化
-   - [] ChatGPTレビュー実施
-   - [] テスト実施
- - [] containers/choco_string
+   - [x] ChatGPTレビュー実施
+ - [x] containers/choco_string
  - [] core/event_system
  - [] core/input_system
+ - [] テスト
+ - [] doxygenコメント追加
+ - [] doxygen(groups.doxメンテナンス)
+ - [] README.mdのtree修正
+ - [] layer.mdメンテナンス
  - [] books執筆
    - [] articleに更新履歴を追加
    - [] 前回、今回やるといった内容との整合性がとれているか確認
@@ -104,6 +108,15 @@ step2 TODO:
    - [] development_logのタイトル整理(2d_rendering/step1が前回まで)
    - [] articleメンテナンス
    - [] book執筆
+
+メモ:
+ - [] book/chapter1: glfw window
+ - [] book/chapter2: strategy
+ - [] book/chapter3: choco_string
+ - [] book/chapter4: memory_system仕様変更
+ - [] book/chapter5: sleep -> application run変更
+ - [] book/chapter6: input system
+ - [] book/chapter7: event system
 
 ### platform/platform_glfwを作ってウィンドウ初期化
 
@@ -118,3 +131,22 @@ step2 TODO:
  - makefileに-DUSE_GLFWを追加し、ビルド時に使用プラットフォームを選択できるようにする
  - 選択したプラットフォーム以外のライブラリ等が存在しなくてもビルドできるように#ifdef USE_XXXを入れる
 ブランチ: feat/2d-rendering-step2 -> feat/apply-strategy-to-platform
+
+### containers/choco_stringの追加
+
+実装内容: platform_stateのwindow_labelをリソース管理機能を持つchoco_stringに変更する
+ブランチ: feat/2d-rendering-step2 -> feat/choco-string
+
+### fix/memory-system, refactor/linear-allocator, refactor/application-create
+
+改善理由:
+memory_systemの実態をアプリケーション側に持たせるのはまずい。memory_system_allocateでいちいちmemory_systemを渡す必要がある
+特に、choco_stringのように様々なところから呼ばれる関数の場合、choco_string_xxxにすべてmemory_systemを渡す必要があり煩わしい
+memory_systemの改善に合わせ、linear_allocatorについても仕様を変更する
+
+- [] fix/memory_system           : 先にfix/memory_systemでmemory_systemの仕様変更を行う
+- [] refactor/linear-allocator.  : linear_allocatorのメモリをmemory_systemで確保するように仕様変更
+- [] refactor/application-create : 上記に合わせ、サブシステム用メモリ総容量を事前に計算してlinear_allocatorでメモリ確保するようapplication変更
+- [] test/memory-refactoring     : 上記仕様変更に合わせて全てのテストコードを追加、修正、テスト実施
+- [] docs/choco-memory           : choco_memory.h, .cのdoxygenコメント修正
+- [] docs/linear-allocator       : linear_allocator.h, .cのdoxygenコメント修正

--- a/src/engine/core/memory/choco_memory.c
+++ b/src/engine/core/memory/choco_memory.c
@@ -13,7 +13,6 @@
 #include <stddef.h>
 #include <stdalign.h>
 #include <stdlib.h> // for malloc TODO: remove this!!
-#include <string.h> // for memset strcmp(test only)
 #include <stdio.h>  // for fprintf
 
 #include "engine/base/choco_macros.h"
@@ -22,6 +21,7 @@
 #include "engine/core/memory/choco_memory.h"
 
 #ifdef TEST_BUILD
+#include <string.h> // for memset strcmp(test only)
 #include <assert.h>
 #include <stdbool.h>
 typedef struct malloc_test {    // TODO: 現状はlinear_allocatorと同じだが、将来的にFreeListになった際に挙動が変わるので、とりあえずコピーを置く
@@ -33,8 +33,6 @@ typedef struct malloc_test {    // TODO: 現状はlinear_allocatorと同じだ�
 static malloc_test_t s_malloc_test;
 
 static void test_test_malloc(void); // TODO: 現状はlinear_allocatorと同じだが、将来的にFreeListになった際に挙動が変わるので、とりあえずコピーを置く
-static void test_memory_system_preinit(void);
-static void test_memory_system_init(void);
 static void test_memory_system_destroy(void);
 static void test_memory_system_allocate(void);
 static void test_memory_system_free(void);
@@ -45,63 +43,60 @@ static void test_memory_system_report(void);
  * @brief メモリーシステム内部状態管理オブジェクト
  *
  */
-struct memory_system {
+typedef struct memory_system {
     size_t total_allocated;                     /**< メモリ総割り当て量 */
     size_t mem_tag_allocated[MEMORY_TAG_MAX];   /**< 各メモリータグごとのメモリ割り当て量 */
     const char* mem_tag_str[MEMORY_TAG_MAX];    /**< 各メモリータグ文字列 */
-};
+} memory_system_t;
+
+static memory_system_t* s_mem_sys_ptr = NULL;
 
 static void* test_malloc(size_t size_); // TODO: 現状はlinear_allocatorと同じだが、将来的にFreeListになった際に挙動が変わるので、とりあえずコピーを置く
 
-void memory_system_preinit(size_t* const memory_requirement_, size_t* const alignment_requirement_) {
-    if(NULL == memory_requirement_ || NULL == alignment_requirement_) {
-        WARN_MESSAGE("memory_system_preinit - No-op: memory_requirement_ or alignment_requirement_ is NULL.");
+memory_sys_err_t memory_system_create(void) {
+    memory_sys_err_t ret = MEMORY_SYSTEM_INVALID_ARGUMENT;
+    if(NULL != s_mem_sys_ptr) {
+        ERROR_MESSAGE("memory_system_create(RUNTIME_ERROR) - Memory system is already initialized.");
+        ret = MEMORY_SYSTEM_RUNTIME_ERROR;
         goto cleanup;
     }
-    *memory_requirement_ = sizeof(memory_system_t);
-    *alignment_requirement_ = alignof(memory_system_t);
-    goto cleanup;
+    s_mem_sys_ptr = (memory_system_t*)malloc(sizeof(memory_system_t));
+    CHECK_ALLOC_FAIL_GOTO_CLEANUP(s_mem_sys_ptr, MEMORY_SYSTEM_NO_MEMORY, "memory_system_create", "s_mem_sys_ptr")
+    memset(s_mem_sys_ptr, 0, sizeof(memory_system_t));
 
-cleanup:
-    return;
-}
-
-memory_sys_err_t memory_system_init(memory_system_t* memory_system_) {
-    memory_sys_err_t ret = MEMORY_SYSTEM_INVALID_ARGUMENT;
-    CHECK_ARG_NULL_GOTO_CLEANUP(memory_system_, MEMORY_SYSTEM_INVALID_ARGUMENT, "memory_system_init", "memory_system_")
-
-    memory_system_->total_allocated = 0;
+    s_mem_sys_ptr->total_allocated = 0;
     for(size_t i = 0; i != MEMORY_TAG_MAX; ++i) {
-        memory_system_->mem_tag_allocated[i] = 0;
+        s_mem_sys_ptr->mem_tag_allocated[i] = 0;
     }
-    memory_system_->mem_tag_str[MEMORY_TAG_SYSTEM] = "system";
-    memory_system_->mem_tag_str[MEMORY_TAG_STRING] = "string";
-
+    s_mem_sys_ptr->mem_tag_str[MEMORY_TAG_SYSTEM] = "system";
+    s_mem_sys_ptr->mem_tag_str[MEMORY_TAG_STRING] = "string";
     ret = MEMORY_SYSTEM_SUCCESS;
 
 cleanup:
     return ret;
 }
 
-void memory_system_destroy(memory_system_t* memory_system_) {
-    if(NULL == memory_system_) {
+void memory_system_destroy(void) {
+    if(NULL == s_mem_sys_ptr) {
         goto cleanup;
     }
-    memory_system_->total_allocated = 0;
+    s_mem_sys_ptr->total_allocated = 0;
     for(size_t i = 0; i != MEMORY_TAG_MAX; ++i) {
-        memory_system_->mem_tag_allocated[i] = 0;
+        s_mem_sys_ptr->mem_tag_allocated[i] = 0;
     }
+    free(s_mem_sys_ptr);
+    s_mem_sys_ptr = NULL;
 
 cleanup:
     return;
 }
 
-memory_sys_err_t memory_system_allocate(memory_system_t* memory_system_, size_t size_, memory_tag_t mem_tag_, void** out_ptr_) {
+memory_sys_err_t memory_system_allocate(size_t size_, memory_tag_t mem_tag_, void** out_ptr_) {
     memory_sys_err_t ret = MEMORY_SYSTEM_INVALID_ARGUMENT;
     void* tmp = NULL;
 
     // Preconditions.
-    CHECK_ARG_NULL_GOTO_CLEANUP(memory_system_, MEMORY_SYSTEM_INVALID_ARGUMENT, "memory_system_allocate", "memory_system_")
+    CHECK_ARG_NULL_GOTO_CLEANUP(s_mem_sys_ptr, MEMORY_SYSTEM_INVALID_ARGUMENT, "memory_system_allocate", "s_mem_sys_ptr")
     CHECK_ARG_NULL_GOTO_CLEANUP(out_ptr_, MEMORY_SYSTEM_INVALID_ARGUMENT, "memory_system_allocate", "out_ptr_")
     CHECK_ARG_NOT_NULL_GOTO_CLEANUP(*out_ptr_, MEMORY_SYSTEM_INVALID_ARGUMENT, "memory_system_allocate", "*out_ptr_")
     CHECK_ARG_NOT_VALID_GOTO_CLEANUP(mem_tag_ < MEMORY_TAG_MAX, MEMORY_SYSTEM_INVALID_ARGUMENT, "memory_system_allocate", "mem_tag_")
@@ -110,13 +105,13 @@ memory_sys_err_t memory_system_allocate(memory_system_t* memory_system_, size_t 
         ret = MEMORY_SYSTEM_SUCCESS;
         goto cleanup;
     }
-    if(memory_system_->mem_tag_allocated[mem_tag_] > (SIZE_MAX - size_)) {
-        ERROR_MESSAGE("memory_system_allocate(INVALID_ARGUMENT) - size_t overflow: tag=%s used=%zu, requested=%zu, sum would exceed SIZE_MAX.", memory_system_->mem_tag_str[mem_tag_], memory_system_->mem_tag_allocated[mem_tag_], size_);
+    if(s_mem_sys_ptr->mem_tag_allocated[mem_tag_] > (SIZE_MAX - size_)) {
+        ERROR_MESSAGE("memory_system_allocate(INVALID_ARGUMENT) - size_t overflow: tag=%s used=%zu, requested=%zu, sum would exceed SIZE_MAX.", s_mem_sys_ptr->mem_tag_str[mem_tag_], s_mem_sys_ptr->mem_tag_allocated[mem_tag_], size_);
         ret = MEMORY_SYSTEM_INVALID_ARGUMENT;
         goto cleanup;
     }
-    if(memory_system_->total_allocated > (SIZE_MAX - size_)) {
-        ERROR_MESSAGE("memory_system_allocate(INVALID_ARGUMENT) - size_t overflow: total_allocated=%zu, requested=%zu, sum would exceed SIZE_MAX.", memory_system_->total_allocated, size_);
+    if(s_mem_sys_ptr->total_allocated > (SIZE_MAX - size_)) {
+        ERROR_MESSAGE("memory_system_allocate(INVALID_ARGUMENT) - size_t overflow: total_allocated=%zu, requested=%zu, sum would exceed SIZE_MAX.", s_mem_sys_ptr->total_allocated, size_);
         ret = MEMORY_SYSTEM_INVALID_ARGUMENT;
         goto cleanup;
     }
@@ -128,8 +123,8 @@ memory_sys_err_t memory_system_allocate(memory_system_t* memory_system_, size_t 
 
     // commit.
     *out_ptr_ = tmp;
-    memory_system_->total_allocated += size_;
-    memory_system_->mem_tag_allocated[mem_tag_] += size_;
+    s_mem_sys_ptr->total_allocated += size_;
+    s_mem_sys_ptr->mem_tag_allocated[mem_tag_] += size_;
     ret = MEMORY_SYSTEM_SUCCESS;
 
 cleanup:
@@ -141,9 +136,9 @@ cleanup:
 // mem_tag_ >= MEMORY_TAG_MAXでワーニング / No-op
 // mem_tag_allocatedがマイナスとなる量をfreeしようとするとワーニング / No-op
 // total_allocatedがマイナスとなる量をfreeしようとするとワーニング / No-op
-void memory_system_free(memory_system_t* memory_system_, void* ptr_, size_t size_, memory_tag_t mem_tag_) {
-    if(NULL == memory_system_) {
-        WARN_MESSAGE("memory_system_free - No-op: memory_system_ is NULL.");
+void memory_system_free(void* ptr_, size_t size_, memory_tag_t mem_tag_) {
+    if(NULL == s_mem_sys_ptr) {
+        WARN_MESSAGE("memory_system_free - No-op: s_mem_sys_ptr is NULL.");
         goto cleanup;
     }
     if(NULL == ptr_) {
@@ -154,34 +149,34 @@ void memory_system_free(memory_system_t* memory_system_, void* ptr_, size_t size
         WARN_MESSAGE("memory_system_free - No-op: invalid mem_tag_.");
         goto cleanup;
     }
-    if(memory_system_->mem_tag_allocated[mem_tag_] < size_) {
+    if(s_mem_sys_ptr->mem_tag_allocated[mem_tag_] < size_) {
         WARN_MESSAGE("memory_system_free - No-op: mem_tag_allocated broken.");
         goto cleanup;
     }
-    if(memory_system_->total_allocated < size_) {
+    if(s_mem_sys_ptr->total_allocated < size_) {
         WARN_MESSAGE("memory_system_free: No-op: total_allocated broken.");
         goto cleanup;
     }
 
     free(ptr_);
-    memory_system_->total_allocated -= size_;
-    memory_system_->mem_tag_allocated[mem_tag_] -= size_;
+    s_mem_sys_ptr->total_allocated -= size_;
+    s_mem_sys_ptr->mem_tag_allocated[mem_tag_] -= size_;
 cleanup:
     return;
 }
 
-void memory_system_report(const memory_system_t* memory_system_) {
-    if(NULL == memory_system_) {
-        WARN_MESSAGE("memory_system_report - No-op: memory_system_ is NULL.");
+void memory_system_report(void) {
+    if(NULL == s_mem_sys_ptr) {
+        WARN_MESSAGE("memory_system_report - No-op: s_mem_sys_ptr is NULL.");
         goto cleanup;
     }
     INFO_MESSAGE("memory_system_report");
     // TODO: [INFORMATION]を出力しないINFO_MESSAGE_RAW(...)をbase/messageに追加し、fprintfを廃止する
-    fprintf(stdout, "\033[1;35m\tTotal allocated: %zu\n", memory_system_->total_allocated);
+    fprintf(stdout, "\033[1;35m\tTotal allocated: %zu\n", s_mem_sys_ptr->total_allocated);
     fprintf(stdout, "\tMemory tag allocated:\n");
     for(size_t i = 0; i != MEMORY_TAG_MAX; ++i) {
-        const char* const tag_str = memory_system_->mem_tag_str[i];
-        fprintf(stdout, "\t\ttag(%s): %zu\n", (NULL != tag_str) ? tag_str : "unknown", memory_system_->mem_tag_allocated[i]);
+        const char* const tag_str = s_mem_sys_ptr->mem_tag_str[i];
+        fprintf(stdout, "\t\ttag(%s): %zu\n", (NULL != tag_str) ? tag_str : "unknown", s_mem_sys_ptr->mem_tag_allocated[i]);
     }
     fprintf(stdout, "\033[0m\n");
 cleanup:
@@ -210,54 +205,10 @@ static void* test_malloc(size_t size_) {
 #ifdef TEST_BUILD
 void test_memory_system(void) {
     test_test_malloc();
-    test_memory_system_preinit();
-    test_memory_system_init();
     test_memory_system_destroy();
     test_memory_system_allocate();
     test_memory_system_free();
     test_memory_system_report();
-}
-
-static void NO_COVERAGE test_memory_system_preinit(void) {
-    size_t memory = 0;
-    size_t align = 0;
-    // memory_requirement_ == NULLでワーニング -> No-op
-    memory_system_preinit(NULL, &align);
-    assert(0 == memory);
-    assert(0 == align);
-
-    // alignment_requirement_ == NULLでワーニング -> No-op
-    memory_system_preinit(&memory, NULL);
-    assert(0 == memory);
-    assert(0 == align);
-
-    memory_system_preinit(&memory, &align);
-    assert(sizeof(memory_system_t) == memory);
-    assert(alignof(memory_system_t) == align);
-}
-
-static void NO_COVERAGE test_memory_system_init(void) {
-    memory_sys_err_t ret = MEMORY_SYSTEM_INVALID_ARGUMENT;
-    // memory_system_ == NULLでMEMORY_SYSTEM_INVALID_ARGUMENT
-    ret = memory_system_init(NULL);
-    assert(MEMORY_SYSTEM_INVALID_ARGUMENT == ret);
-
-    memory_system_t* system = NULL;
-    size_t memory = 0;
-    size_t align = 0;
-    memory_system_preinit(&memory, &align);
-    system = (memory_system_t*)malloc(memory);
-    ret = memory_system_init(system);
-    assert(0 == strcmp(system->mem_tag_str[MEMORY_TAG_SYSTEM], "system"));
-    assert(0 == strcmp(system->mem_tag_str[MEMORY_TAG_STRING], "string"));
-    assert(MEMORY_SYSTEM_SUCCESS == ret);
-    assert(0 == system->total_allocated);
-    for(size_t i = 0; i != MEMORY_TAG_MAX; ++i) {
-        assert(0 == system->mem_tag_allocated[i]);
-    }
-
-    free(system);
-    system = NULL;
 }
 
 static void NO_COVERAGE test_memory_system_destroy(void) {


### PR DESCRIPTION
- application側に持たせるやり方では、choco_stringAPIを使用する際にmemory_systemをAPIに渡さなくては行けなく、あまりに不便