### PR TITLE
refactor: linear-allocator

### DIFF
--- a/docs/development_log.md
+++ b/docs/development_log.md
@@ -144,9 +144,10 @@ memory_systemの実態をアプリケーション側に持たせるのはまず�
 特に、choco_stringのように様々なところから呼ばれる関数の場合、choco_string_xxxにすべてmemory_systemを渡す必要があり煩わしい
 memory_systemの改善に合わせ、linear_allocatorについても仕様を変更する
 
-- [] fix/memory_system           : 先にfix/memory_systemでmemory_systemの仕様変更を行う
-- [] refactor/linear-allocator.  : linear_allocatorのメモリをmemory_systemで確保するように仕様変更
+- [x] fix/memory_system          : 先にfix/memory_systemでmemory_systemの仕様変更を行う
+- [x] refactor/linear-allocator  : linear_allocatorのメモリをmemory_systemで確保するように仕様変更
 - [] refactor/application-create : 上記に合わせ、サブシステム用メモリ総容量を事前に計算してlinear_allocatorでメモリ確保するようapplication変更
+- [] refactor/memory-system      : destroyの際にtotal_allocatedが0でない場合にワーニングを出力
 - [] test/memory-refactoring     : 上記仕様変更に合わせて全てのテストコードを追加、修正、テスト実施
-- [] docs/choco-memory           : choco_memory.h, .cのdoxygenコメント修正
+- [] docs/choco-memory           : choco_memory.h, .cのdoxygenコメント修正, memory_system_allocate_aligneをtodoに追加(FreeListの後)
 - [] docs/linear-allocator       : linear_allocator.h, .cのdoxygenコメント修正

--- a/include/engine/core/memory/linear_allocator.h
+++ b/include/engine/core/memory/linear_allocator.h
@@ -51,52 +51,9 @@ typedef enum {
     LINEAR_ALLOC_INVALID_ARGUMENT,  /**< 無効な引数 */
 } linear_alloc_err_t;
 
-/**
- * @brief linear_alloc_tオブジェクトを生成する
- *
- * @note 使用の際の前提条件
- * - 引数allocator_はNULLで初期化したlinear_alloc_t*型変数のアドレスを渡すこと
- * - 引数capacity_は0より大きい値を使用すること
- *
- * 使用例:
- * @code
- * linear_alloc_t* alloc = NULL;    // 必ずNULL初期化をすること
- * linear_alloc_err_t ret = linear_allocator_create(&alloc, 128);   // 128byteの容量でアロケータを生成
- * // エラー処理
- * linear_allocator_destroy(&alloc);    // オブジェクトを破棄
- * @endcode
- *
- * @param[out] allocator_ linear_alloc_t*型オブジェクトへのポインタ(create内でsizeof(linear_alloc_t)のメモリを確保するためダブルポインタを使用)
- * @param[in] capacity_ アロケータ保有メモリ容量(byte)
- *
- * @retval LINEAR_ALLOC_INVALID_ARGUMENT 引数allocator_ == NULL
- * @retval LINEAR_ALLOC_INVALID_ARGUMENT 引数*allocator_ != NULL
- * @retval LINEAR_ALLOC_INVALID_ARGUMENT 引数capacity_ == 0
- * @retval LINEAR_ALLOC_NO_MEMORY        メモリ確保失敗
- * @retval LINEAR_ALLOC_SUCCESS          オブジェクトの生成に成功し正常終了
- */
-linear_alloc_err_t linear_allocator_create(linear_alloc_t** allocator_, size_t capacity_);
+void linear_allocator_preinit(size_t* memory_requirement_, size_t* align_requirement_);
 
-/**
- * @brief linear_alloc_tオブジェクトを破棄する
- *
- * @note 本APIを使用することで、linear_alloc_t*型変数が有しているメモリも破棄され、*allocator_にはNULLが代入される
- *
- * @note 下記の場合は何もしない
- * - allocator_がNULL(linear_allocator_destroy(NULL)のケース)
- * - *allocator_がNULL(2重destroyをしたケース)
- *
- * 使用例:
- * @code
- * linear_alloc_t* alloc = NULL;    // 必ずNULL初期化をすること
- * linear_alloc_err_t ret = linear_allocator_create(&alloc, 128);   // 128byteの容量でアロケータを生成
- * // エラー処理
- * linear_allocator_destroy(&alloc);    // オブジェクトを破棄(これでalloc == NULLになる)
- * @endcode
- *
- * @param[in,out] allocator_ linear_alloc_t*型オブジェクトへのポインタ(destroy内でallocator_が有しているメモリを解放するためダブルポインタを使用)
- */
-void linear_allocator_destroy(linear_alloc_t** allocator_);
+linear_alloc_err_t linear_allocator_init(linear_alloc_t* allocator_, size_t capacity_, void* memory_pool_);
 
 /**
  * @brief linear_allocatorを使用してメモリを割り当てる

--- a/src/engine/core/memory/choco_memory.c
+++ b/src/engine/core/memory/choco_memory.c
@@ -12,6 +12,7 @@
  */
 #include <stddef.h>
 #include <stdalign.h>
+#include <string.h> // for memset strcmp(test only)
 #include <stdlib.h> // for malloc TODO: remove this!!
 #include <stdio.h>  // for fprintf
 
@@ -21,7 +22,6 @@
 #include "engine/core/memory/choco_memory.h"
 
 #ifdef TEST_BUILD
-#include <string.h> // for memset strcmp(test only)
 #include <assert.h>
 #include <stdbool.h>
 typedef struct malloc_test {    // TODO: 現状はlinear_allocatorと同じだが、将来的にFreeListになった際に挙動が変わるので、とりあえずコピーを置く

--- a/src/engine/core/memory/linear_allocator.c
+++ b/src/engine/core/memory/linear_allocator.c
@@ -14,6 +14,7 @@
 #include <stdlib.h> // for malloc TODO: remove this!!
 #include <string.h> // for memset
 #include <stdbool.h>
+#include <stdalign.h>
 #include <stdint.h>
 
 #include "engine/core/memory/linear_allocator.h"
@@ -41,79 +42,32 @@ typedef struct malloc_test {
 
 static malloc_test_t s_malloc_test;
 static void test_test_malloc(void);
-static void test_linear_allocator_create(void);
-static void test_linear_allocator_destroy(void);
 static void test_linear_allocator_allocate(void);
 #endif
 
 static void* test_malloc(size_t size_);
 
-// 引数allocator_ == NULLでLINEAR_ALLOC_INVALID_ARGUMENT
-// 引数*allocator_ != NULLでLINEAR_ALLOC_INVALID_ARGUMENT
-// 引数capacity_ == 0でLINEAR_ALLOC_INVALID_ARGUMENT
-// 1回目のmallocに失敗でLINEAR_ALLOC_NO_MEMORY + リソース解放なし
-// 2回目のmallocに失敗でLINEAR_ALLOC_NO_MEMORY + リソース解放
-linear_alloc_err_t linear_allocator_create(linear_alloc_t** allocator_, size_t capacity_) {
+void linear_allocator_preinit(size_t* memory_requirement_, size_t* align_requirement_) {
+    if(NULL == memory_requirement_ || NULL == align_requirement_) {
+        return;
+    }
+    *memory_requirement_ = sizeof(linear_alloc_t);
+    *align_requirement_ = alignof(linear_alloc_t);
+}
+
+linear_alloc_err_t linear_allocator_init(linear_alloc_t* allocator_, size_t capacity_, void* memory_pool_) {
     linear_alloc_err_t ret = LINEAR_ALLOC_INVALID_ARGUMENT;
-    linear_alloc_t* tmp = NULL;
+    CHECK_ARG_NULL_GOTO_CLEANUP(allocator_, LINEAR_ALLOC_INVALID_ARGUMENT, "linear_allocator_init", "allocator_")
+    CHECK_ARG_NULL_GOTO_CLEANUP(memory_pool_, LINEAR_ALLOC_INVALID_ARGUMENT, "linear_allocator_init", "memory_pool_")
+    CHECK_ARG_NOT_VALID_GOTO_CLEANUP(0 != capacity_, LINEAR_ALLOC_INVALID_ARGUMENT, "linear_allocator_init", "capacity_")
 
-    // Preconditions
-    CHECK_ARG_NULL_GOTO_CLEANUP(allocator_, LINEAR_ALLOC_INVALID_ARGUMENT, "linear_allocator_create", "allocator_")
-    CHECK_ARG_NOT_NULL_GOTO_CLEANUP(*allocator_, LINEAR_ALLOC_INVALID_ARGUMENT, "linear_allocator_create", "allocator_")
-    CHECK_ARG_NOT_VALID_GOTO_CLEANUP(0 != capacity_, LINEAR_ALLOC_INVALID_ARGUMENT, "linear_allocator_create", "capacity_")
-
-    // Simulation
-    tmp = (linear_alloc_t*)test_malloc(sizeof(*tmp));    // TODO: choco_malloc()
-    CHECK_ALLOC_FAIL_GOTO_CLEANUP(tmp, LINEAR_ALLOC_NO_MEMORY, "linear_allocator_create", "tmp")
-    memset(tmp, 0, sizeof(*tmp));
-
-    tmp->memory_pool = test_malloc(capacity_);   // TODO: choco_malloc()
-    CHECK_ALLOC_FAIL_GOTO_CLEANUP(tmp->memory_pool, LINEAR_ALLOC_NO_MEMORY, "linear_allocator_create", "tmp->memory_pool")
-    memset(tmp->memory_pool, 0, capacity_);
-
-    tmp->capacity = capacity_;
-    tmp->head_ptr = tmp->memory_pool;
-
-    // commit
-    *allocator_ = tmp;
+    allocator_->capacity = capacity_;
+    allocator_->head_ptr = memory_pool_;
+    allocator_->memory_pool = memory_pool_;
     ret = LINEAR_ALLOC_SUCCESS;
 
 cleanup:
-    if(LINEAR_ALLOC_SUCCESS != ret) {
-        if(NULL != tmp && NULL != tmp->memory_pool) {
-            free(tmp->memory_pool); // TODO: choco_free
-            tmp->memory_pool = NULL;
-        }
-        if(NULL != tmp) {
-            free(tmp);
-            tmp = NULL;
-        }
-    }
     return ret;
-}
-
-// 引数allocator_ == NULLでno-op
-// 引数*allocator_ == NULLでno-op
-// 2重destroy OK
-void linear_allocator_destroy(linear_alloc_t** allocator_) {
-    // TODO: choco_free
-    if(NULL == allocator_) {
-        goto cleanup;
-    }
-    if(NULL == *allocator_) {
-        goto cleanup;
-    }
-    if(NULL != (*allocator_)->memory_pool) {
-        free((*allocator_)->memory_pool);
-        (*allocator_)->memory_pool = NULL;
-    }
-    (*allocator_)->capacity = 0;
-    (*allocator_)->head_ptr = NULL;
-    free(*allocator_);
-    *allocator_ = NULL;
-
-cleanup:
-    return;
 }
 
 linear_alloc_err_t linear_allocator_allocate(linear_alloc_t* allocator_, size_t req_size_, size_t req_align_, void** out_ptr_) {
@@ -204,86 +158,9 @@ void test_linear_allocator(void) {
     test_test_malloc();
     INFO_MESSAGE("test_test_malloc done successfully.");
 
-    INFO_MESSAGE("test_linear_allocator_create begin");
-    test_linear_allocator_create();
-    INFO_MESSAGE("test_linear_allocator_create done successfully.");
-
-    INFO_MESSAGE("test_linear_allocator_destroy begin");
-    test_linear_allocator_destroy();
-    INFO_MESSAGE("test_linear_allocator_destroy done successfully.");
-
     INFO_MESSAGE("test_linear_allocator_allocate begin");
     test_linear_allocator_allocate();
     INFO_MESSAGE("test_linear_allocator_allocate done successfully.");
-}
-
-static void NO_COVERAGE test_linear_allocator_create(void) {
-    linear_alloc_err_t ret = LINEAR_ALLOC_INVALID_ARGUMENT;
-    {
-        // 引数allocator_ == NULLでLINEAR_ALLOC_INVALID_ARGUMENT
-        ret = linear_allocator_create(NULL, 128);
-        assert(LINEAR_ALLOC_INVALID_ARGUMENT == ret);
-
-        // 引数capacity_ == 0でLINEAR_ALLOC_INVALID_ARGUMENT
-        linear_alloc_t* alloc = NULL;
-        ret = linear_allocator_create(&alloc, 0);
-        assert(LINEAR_ALLOC_INVALID_ARGUMENT == ret);
-
-        // success
-        ret = linear_allocator_create(&alloc, 128);
-        assert(LINEAR_ALLOC_SUCCESS == ret);
-        assert(128 == alloc->capacity);
-        assert(alloc->head_ptr == alloc->memory_pool);
-
-        // 引数*allocator_ != NULLでLINEAR_ALLOC_INVALID_ARGUMENT
-        ret = linear_allocator_create(&alloc, 128);
-        assert(LINEAR_ALLOC_INVALID_ARGUMENT == ret);
-
-        linear_allocator_destroy(&alloc);
-        assert(NULL == alloc);
-    }
-    {
-        s_malloc_test.fail_enable = true;
-        s_malloc_test.malloc_counter = 0;
-        s_malloc_test.malloc_fail_n = 0;    // 1回目で失敗 + リソース解放なし
-
-        linear_alloc_t* alloc = NULL;
-        ret = linear_allocator_create(&alloc, 128);
-        assert(LINEAR_ALLOC_NO_MEMORY == ret);
-
-        linear_allocator_destroy(&alloc);
-        assert(NULL == alloc);
-    }
-    {
-        s_malloc_test.fail_enable = true;
-        s_malloc_test.malloc_counter = 0;
-        s_malloc_test.malloc_fail_n = 1;    // 2回目で失敗 + リソース解放
-
-        linear_alloc_t* alloc = NULL;
-        ret = linear_allocator_create(&alloc, 128);
-        assert(LINEAR_ALLOC_NO_MEMORY == ret);
-
-        linear_allocator_destroy(&alloc);
-        assert(NULL == alloc);
-    }
-}
-
-static void NO_COVERAGE test_linear_allocator_destroy(void) {
-    {
-        linear_allocator_destroy(NULL); // 引数allocator_ == NULLでno-op
-
-        linear_alloc_t* alloc = NULL;
-        linear_allocator_destroy(&alloc);   // 引数*allocator_ == NULLでno-op
-
-        linear_alloc_err_t ret = linear_allocator_create(&alloc, 128);
-        assert(LINEAR_ALLOC_SUCCESS == ret);
-        assert(128 == alloc->capacity);
-        assert(alloc->head_ptr == alloc->memory_pool);
-
-        linear_allocator_destroy(&alloc);
-        assert(NULL == alloc);
-        linear_allocator_destroy(&alloc);
-    }
 }
 
 static void NO_COVERAGE test_linear_allocator_allocate(void) {
@@ -318,7 +195,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         assert(LINEAR_ALLOC_SUCCESS == ret);
         assert(NULL == out_ptr);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
     {
@@ -336,7 +212,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         assert(LINEAR_ALLOC_NO_MEMORY == ret);
         assert(NULL == out_ptr2);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
     {
@@ -348,7 +223,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         ret = linear_allocator_allocate(alloc, 8, 1, &out_ptr); // ギリギリサイズ
         assert(LINEAR_ALLOC_SUCCESS == ret);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
     {
@@ -361,7 +235,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         assert(LINEAR_ALLOC_NO_MEMORY == ret);
         assert(NULL == out_ptr);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
     {
@@ -373,7 +246,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         ret = linear_allocator_allocate(alloc, SIZE_MAX, 2, &out_ptr); // 要求サイズが過大
         assert(LINEAR_ALLOC_INVALID_ARGUMENT == ret);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
     {
@@ -385,7 +257,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         ret = linear_allocator_allocate(alloc, 6, 7, &out_ptr); // アライメントが2の冪乗じゃないのでLINEAR_ALLOC_INVALID_ARGUMENT
         assert(LINEAR_ALLOC_INVALID_ARGUMENT == ret);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
     {
@@ -397,7 +268,6 @@ static void NO_COVERAGE test_linear_allocator_allocate(void) {
         ret = linear_allocator_allocate(alloc, 6, 2, &out_ptr); // 正常
         assert(LINEAR_ALLOC_SUCCESS == ret);
 
-        linear_allocator_destroy(&alloc);
         alloc = NULL;
     }
 }


### PR DESCRIPTION
- リニアアロケータのメモリをmemory_system経由で取得するよう仕様変更
- リニアアロケータがmemory_systemに依存することは避けたいため、application側でlinear_allocatorのリソースを管理するよう変更